### PR TITLE
Fix smooth scroll offset in JS

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (targetElement) {
                 window.scrollTo({
-                    top: targetElement.offsetTop - 100, // Offset for the header
+                    top: targetElement.getBoundingClientRect().top + window.pageYOffset - 100, // Offset for the header
                     behavior: 'smooth'
                 });
             }

--- a/makethingsnotads/js/main.js
+++ b/makethingsnotads/js/main.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             if (targetElement) {
                 window.scrollTo({
-                    top: targetElement.offsetTop - 100, // Offset for the header
+                    top: targetElement.getBoundingClientRect().top + window.pageYOffset - 100, // Offset for the header
                     behavior: 'smooth'
                 });
             }


### PR DESCRIPTION
## Summary
- ensure smooth scrolling uses `getBoundingClientRect` and `pageYOffset`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849a84ce328832ca6a3b5c98de82bf2