### PR TITLE
Add Jest setup with jsdom test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "makethingsnotads",
+  "version": "1.0.0",
+  "description": "A modern landing page for a social media marketing consultancy specializing in AI-enhanced content creation.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+
+describe('smooth scroll handler', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <header></header>
+      <a href="#target" id="link">link</a>
+      <div id="target"></div>
+    `;
+
+    const target = document.getElementById('target');
+    Object.defineProperty(target, 'offsetTop', { value: 500, writable: true });
+
+    window.scrollTo = jest.fn();
+
+    const scriptPath = path.join(__dirname, '..', 'js', 'main.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    eval(scriptContent);
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('clicking anchor scrolls to element offset minus header', () => {
+    const link = document.getElementById('link');
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 400,
+      behavior: 'smooth'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest and jsdom dev dependencies
- test smooth scroll handler using jsdom environment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a84e9988832ca14bd8576039ed63