### PR TITLE
Expand Creative Circus case study metrics

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -130,6 +130,54 @@ a:hover {
 .btn-primary:active {
     transform: translateY(-1px);
 }
+.btn-secondary {
+    display: inline-block;
+    background-color: var(--secondary-color);
+    color: white;
+    padding: 10px 25px;
+    border-radius: 50px;
+    text-transform: uppercase;
+    font-weight: 700;
+    letter-spacing: 1px;
+    transition: var(--transition);
+    border: none;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    z-index: 1;
+    margin-top: 15px;
+}
+.btn-secondary:after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 0;
+    background-color: var(--primary-color);
+    transition: all 0.3s ease;
+    z-index: -1;
+}
+.btn-secondary:hover {
+    color: white;
+    transform: translateY(-3px);
+    box-shadow: var(--box-shadow);
+}
+.btn-secondary:hover:after {
+    height: 100%;
+}
+.btn-secondary:active {
+    transform: translateY(-1px);
+}
+.case-study-details {
+    display: none;
+    margin-top: 15px;
+}
+.case-study-details.show {
+    display: block;
+    animation: fadeInUp 0.4s ease forwards;
+}
+
 
 /* Header & Navigation */
 header {

--- a/index.html
+++ b/index.html
@@ -242,8 +242,10 @@
                 <h3>The Creative Circus</h3>
                 <div class="case-study-content">
                     <div class="case-study-text">
-                        <p>We helped The Creative Circus enhance their social media presence through a combination of organic content strategy and AI-powered content creation.</p>
-                        <p>The result: 150% increase in engagement and 75% growth in qualified leads within the first quarter.</p>
+                        <p>As our very first client, <strong>The Creative Circus</strong> trusted us to build their entire social strategy from the ground up. We blended organic and paid campaigns using our AI-enhanced workflow to maximize reach and efficiency.</p>
+                        <button id="circus-toggle" class="btn-secondary">View Results</button>
+                        <div id="circus-details" class="case-study-details">
+                        <p>Within three months, campaigns generated nearly <strong>one million impressions</strong> while maintaining a cost per conversion of under <strong>$20</strong>. Engagement jumped by 150% and qualified leads grew 75%, showcasing the power of pairing creativity with data-driven insights.</p>
                     </div>
                     <div class="case-study-image">
                         <!-- Placeholder for case study image -->

--- a/js/main.js
+++ b/js/main.js
@@ -63,6 +63,16 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Form submission
     const contactForm = document.getElementById('contact-form');
+    // Creative Circus case study toggle
+    const circusToggle = document.getElementById("circus-toggle");
+    const circusDetails = document.getElementById("circus-details");
+    if (circusToggle && circusDetails) {
+        circusToggle.addEventListener("click", () => {
+            circusDetails.classList.toggle("show");
+            circusToggle.textContent = circusDetails.classList.contains("show") ? "Hide Results" : "View Results";
+        });
+    }
+
     
     if (contactForm) {
         contactForm.addEventListener('submit', function(e) {

--- a/makethingsnotads/index.html
+++ b/makethingsnotads/index.html
@@ -231,8 +231,10 @@
                 <h3>The Creative Circus</h3>
                 <div class="case-study-content">
                     <div class="case-study-text">
-                        <p>We helped The Creative Circus enhance their social media presence through a combination of organic content strategy and AI-powered content creation.</p>
-                        <p>The result: 150% increase in engagement and 75% growth in qualified leads within the first quarter.</p>
+                        <p>As our very first client, <strong>The Creative Circus</strong> trusted us to build their entire social strategy from the ground up. We blended organic and paid campaigns using our AI-enhanced workflow to maximize reach and efficiency.</p>
+                        <button id="circus-toggle" class="btn-secondary">View Results</button>
+                        <div id="circus-details" class="case-study-details">
+                        <p>Within three months, campaigns generated nearly <strong>one million impressions</strong> while maintaining a cost per conversion of under <strong>$20</strong>. Engagement jumped by 150% and qualified leads grew 75%, showcasing the power of pairing creativity with data-driven insights.</p>
                     </div>
                     <div class="case-study-image">
                         <!-- Placeholder for case study image -->


### PR DESCRIPTION
## Summary
- expand The Creative Circus case study copy with more detailed metrics
- add show/hide button for Creative Circus stats

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849adb5a664832c957c26eea911232d